### PR TITLE
Fixed the example resource_type in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ resource_types:
   type: docker-image
   privileged: true
   source:
-    repository: starkandwayne/docker-image-resource
+    repository: starkandwayne/docker-buildx-resource
     tag: latest
 
 resources:


### PR DESCRIPTION
This patch updates the README file to properly
show an example resource_types entry's repository attribute.

Using the following fails.
source:
    repository: starkandwayne/docker-image-resource
    tag: latest

Changed to make it work:
source:
    repository: starkandwayne/docker-buildx-resource
    tag: latest